### PR TITLE
Update travic node runtime to 10.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ sudo: false
 
 matrix:
   include:
-  - node_js: "8"
+  - node_js: "10"
     env: TEST_SCRIPT=test
 
 addons:


### PR DESCRIPTION
Node 10.X is now LTS. We should probably switch.

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] `.d.ts` file is updated
- [ ] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
